### PR TITLE
Build web-client using wasm32-unknown-unknown in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,36 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
-matrix:
+
+cache: cargo
+
+jobs:
+  # Allow nightly failures / don't wait for nightly to finish build
   allow_failures:
     - rust: nightly
   fast_finish: true
 
-script:
-  - cargo build --verbose --all
-  - cargo test --verbose --all
+  include:
+    - name: "build and test workspace - stable"
+      rust: stable
+      script:
+        - cargo build --verbose --all
+        - cargo test --verbose --all
+
+    - name: "build and test workspace - beta"
+      rust: beta
+      script:
+        - cargo build --verbose --all
+        - cargo test --verbose --all
+
+    - name: "build and test workspace - nightly"
+      rust: nightly
+      script:
+        - cargo build --verbose --all
+        - cargo test --verbose --all
+
+    - name: "build web-client / wasm-bindgen - stable"
+      rust: stable
+      install:
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - sh web-client/build.sh
+

--- a/web-client/build.sh
+++ b/web-client/build.sh
@@ -4,18 +4,25 @@
 # This allows you to run this script from anywhere and have it still work.
 cd $(dirname $0)
 
+# Install wasm-bindgen if its not there already
+# This is done here mostly becuase cargo install errors
+# if tool is installed / cache, which is rough on CI
+if [ ! -f $HOME/.cargo/bin/wasm-bindgen ]; then
+  cargo install wasm-bindgen-cli --version 0.2.29
+fi
+
 # ./build.sh
 if [ -z "$RELEASE"  ]; then
   # --------------------------------------------------
   # DEVELOPMENT BUILD
   # --------------------------------------------------
 
-  # Build the webgl_water_tutorial.wasm file
+  # Build the tacit_web_app.wasm file
   RUST_BACKTRACE=1 cargo build --target wasm32-unknown-unknown
 
-  # # Process the webgl_water_tutorial.wasm file and generate the necessary
-  # # JavaScript glue code to run it in the browser.
-  wasm-bindgen ./target/wasm32-unknown-unknown/debug/tacit_web_app.wasm --out-dir . --no-typescript --no-modules
+  # Process the tacit_web_app.wasm file and generate the necessary
+  # JavaScript glue code to run it in the browser.
+  wasm-bindgen ../target/wasm32-unknown-unknown/debug/tacit_web_app.wasm --out-dir . --no-typescript --no-modules
 
 # RELEASE=1 ./build.sh
 else
@@ -26,7 +33,7 @@ else
 
   # Build the webgl_water_tutorial.wasm file
   cargo build --target wasm32-unknown-unknown --release &&
-  wasm-bindgen ./target/wasm32-unknown-unknown/release/tacit_web_app.wasm --out-dir . --no-typescript --no-modules &&
+  wasm-bindgen ../target/wasm32-unknown-unknown/release/tacit_web_app.wasm --out-dir . --no-typescript --no-modules &&
   wasm-opt -O3 -o optimized.wasm tacit_web_app_bg.wasm  &&
   mv optimized.wasm tacit_web_app_bg.wasm
 fi


### PR DESCRIPTION
This required changes to the layout of the travis.yml file, as well as build.sh. Also makes sense to turn on the travis cache since it benefits normal builds and compiling wasm-bindgen is expensive.